### PR TITLE
chore: fix typo, fix capitalization of noun

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Detect running environment of the current Node.js process.
 
 ## Installation
 
-Using yarn:
+Using Yarn:
 
 ```
 yarn add std-env
 ```
 
-Usin npm:
+Using npm:
 
 ```
 npm i std-env


### PR DESCRIPTION
## Changes:

- Fix typo
- Yarn is a noun and so should be capitalized

## Context:

Fix small stuff in the README.md file.